### PR TITLE
Fixes missing class declarations for TaxonRank:TaxonRankTerm and Team:Team

### DIFF
--- a/ontology/voc/TaxonConcept.rdf
+++ b/ontology/voc/TaxonConcept.rdf
@@ -126,6 +126,9 @@
       <dc:relation rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#rankString"/>
    </owl:ObjectProperty>
 
+    <!-- TaxonRank::TaxonRankTerm -->
+    <owl:Class rdf:about="http://rs.tdwg.org/ontology/voc/TaxonRank#TaxonRankTerm"/>
+
    <!-- TaxonConcept::rankString -->
    <owl:DatatypeProperty rdf:ID="rankString">
       <rdfs:label>Rank String</rdfs:label>

--- a/ontology/voc/TaxonName.rdf
+++ b/ontology/voc/TaxonName.rdf
@@ -293,6 +293,9 @@
       <dc:relation rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#rankString"/>
    </owl:ObjectProperty>
 
+   <!-- TaxonRank::TaxonRankTerm -->
+   <owl:Class rdf:about="http://rs.tdwg.org/ontology/voc/TaxonRank#TaxonRankTerm"/>
+	
    <!-- TaxonName::rankString -->
    <owl:DatatypeProperty rdf:ID="rankString">
       <rdfs:label>Rank String</rdfs:label>

--- a/ontology/voc/TaxonName.rdf
+++ b/ontology/voc/TaxonName.rdf
@@ -218,6 +218,9 @@
       <dc:relation rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonName#combinationAuthorship"/>
    </owl:ObjectProperty>
 
+   <!-- Team::Team -->
+   <owl:Class rdf:about="http://rs.tdwg.org/ontology/voc/Team#Team"/>
+
    <!-- TaxonName::year -->
    <owl:DatatypeProperty rdf:ID="year">
       <rdfs:label>Publication Year</rdfs:label>


### PR DESCRIPTION
Without this declaration, it defaults to a datatype, making the `tc:rank` property declaration become punned between an ObjectProperty (with a domain constraint and all the annotation) and a DatatypeProperty (with range constraint on `TaxonRankTerm`). While not only obviously undesired (and undesirable), this in turn will lead to a DL reasoner error on the undeclared datatype `TaxonRankTerm` (which was never meant to be a datatype), resulting in failure to include the ontology in anything that requires OWL reasoning.

An alternative for fixing the issue would be to `owl:imports` the TaxonRank vocabulary. However, I have to say I actually _appreciate_ that the TaxonConcept ontology doesn't import `Base`, `Common`, etc, and thus is nicely self-contained for those who just care about the taxon concept vocabulary.