### PR TITLE
Fixes datatype for comment metadata on ontology

### DIFF
--- a/ontology/voc/TaxonConcept.rdf
+++ b/ontology/voc/TaxonConcept.rdf
@@ -21,7 +21,7 @@
 
       <owl:versionInfo>0.3</owl:versionInfo>
 
-      <rdfs:comment rdf:parseType="Literal"> This is not a full rendering of TaxonConcept as
+      <rdfs:comment rdf:datatype="xsd:string"> This is not a full rendering of TaxonConcept as
          presented in the Taxon Concept Schema 1.0. Not all the possible concept-concept
          relationships have been modelled just the basic set theory and taxonomic hierarchy
          relationships. RelationshipAssertions have not been included. These omissions will be

--- a/ontology/voc/TaxonName.rdf
+++ b/ontology/voc/TaxonName.rdf
@@ -15,7 +15,7 @@
 
       <owl:versionInfo>0.3</owl:versionInfo>
 
-      <rdfs:comment rdf:parseType="Literal"> This vocabulary closely follows the structure of the ScientificName complex type that is part of the TDWG standard Taxon Concept Schema. The TCS structure was based
+      <rdfs:comment rdf:datatype="xsd:string"> This vocabulary closely follows the structure of the ScientificName complex type that is part of the TDWG standard Taxon Concept Schema. The TCS structure was based
          on the name structures suggested by the LinneanCore and those found in schemas such as ABCD. 
          It reflects the contributions of many authors over a number of years.</rdfs:comment>
       <rdfs:comment>Version 0.3 removed subclass declarations to classes outside of this ontology in accordance with Recommendation 2.9 of the VoMaG Report http://www.gbif.org/resource/80862</rdfs:comment>


### PR DESCRIPTION
`rdf:parseType=Literal` means a datatype of `rdf:XMLLiteral`, which the content violates. There doesn't seem to be any reason to not simply use `xsd:string`?